### PR TITLE
Fix for readr 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     xml2 (>= 1.2.0),
     magrittr,
     stringr (>= 1.3.0),
-    readr (>= 1.0.0),
+    readr (>= 1.2.0),
     tibble (>= 1.4.1),
     rlang (>= 0.2.0),
     furrr (>= 0.1.0),

--- a/tests/testthat/test-writing-to-file.R
+++ b/tests/testthat/test-writing-to-file.R
@@ -64,7 +64,7 @@ test_that("writing error messages to file works", {
                         n_batches = 1)
 
   res <- read_csv(file.path(temp_dir, "meta_data_broken-1.csv"),
-                  col_names = TRUE)
+                  col_names = TRUE, col_types = cols(id = col_integer()))
 
   # the following is needed for expect_identical
   attr(res, "spec") <- NULL


### PR DESCRIPTION
readr 1.2.0 no longer guesses columns are of type integer, instead these
columns are guessed as numeric. See
https://github.com/tidyverse/readr/blob/master/NEWS.md#integer-column-guessing
for details.

There was a test which broke due to this change, and was fixed by
specifying explicitly the type of id to be integer.

Sorry for the breakage!

I plan to submit readr 1.2.0 soon, so you will need to submit jstor after it is accepted to prevent test failures on CRAN.